### PR TITLE
get image resource and title in rootline mode

### DIFF
--- a/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Classes/ViewHelpers/ImageViewHelper.php
@@ -67,8 +67,8 @@ class Tx_Supersized_ViewHelpers_ImageViewHelper extends Tx_Fluid_Core_ViewHelper
 
 		foreach ($backgroundImages as $image) {
 			$images[] = array(
-				'image' => $this->renderImage($image['resource'], $width, $height),
-				'title' => $image['title'],
+        'image' => $this->renderImage($image->getResource(), $width, $height),
+        'title' => $image->getTitle(),
 			);
 		}
 


### PR DESCRIPTION
Before these changes, the rootline mode will throws the following errors in webserver log files

stderr: PHP Fatal error: Cannot use object of type Tx_Supersized_Domain_Model_Resource as array
in /path/to/typo3conf/ext/supersized/Classes/ViewHelpers/ImageViewHelper.php on line 70
stderr: PHP Fatal error: Cannot use object of type Tx_Supersized_Domain_Model_Resource as array
in /path/to/typo3conf/ext/supersized/Classes/ViewHelpers/ImageViewHelper.php on line 71 
